### PR TITLE
Update Nova7MixController.c

### DIFF
--- a/Nova7MixController.c
+++ b/Nova7MixController.c
@@ -18,7 +18,7 @@ int main( int argc, char *argv[] )
 
 	while(1){
 		//Open a process with headsetcontrol
-		fp = popen("headsetcontrol -m -c", "r");
+		fp = popen("headsetcontrol -m -o ENV | grep -E "DEVICE_0_CHATMIX=(.*)" | cut -d '=' -f2", "r");
 		if (fp == NULL) {
 			printf("Failed to run command\n" );
 			exit(EXIT_FAILURE);


### PR DESCRIPTION
headsetcontrol has deprecated -c  in favor of -o  for output. this should remove mass amounts of warnings from system logs.

another alternative would be to use jq, but that requires another install.

headsetcontrol -m -o JSON | jq '.devices.[].chatmix'